### PR TITLE
fix: update static queries dir

### DIFF
--- a/packages/gatsby-plugin-graphql-component/gatsby-node.js
+++ b/packages/gatsby-plugin-graphql-component/gatsby-node.js
@@ -86,7 +86,7 @@ exports.onPreBuild = async ({ store }) => {
     store.getState().staticQueryComponents.forEach(value => {
       promises.push(
         new Promise((resolve, reject) => {
-          fs.readFile(path.join(directory, `public`, `static`, `d`, `${value.hash}.json`), `utf-8`)
+          fs.readFile(path.join(directory, `public`, `page-data`, `sq`, `d`, `${value.hash}.json`), `utf-8`)
             .then(data => {
               const result = JSON.parse(data)
 


### PR DESCRIPTION
Hi @pristas-peter,
Regarding to Gatsby issue [#26135](https://github.com/gatsbyjs/gatsby/issues/26135) I updated static queries dir. 

The previous path causes build errors:

![image](https://user-images.githubusercontent.com/10927960/98688320-022e6580-236b-11eb-84de-cf0c489fb480.png)
